### PR TITLE
Issue No #36 [BUG FIXED] In the footer section, the copyright year should be dynamically generated instead of being statically hardcoded.

### DIFF
--- a/copyrightYear.js
+++ b/copyrightYear.js
@@ -1,0 +1,4 @@
+let copyRightYear = document.getElementById("copyright-year");
+let currentDate = new Date();
+let currentYear = currentDate.getFullYear();
+copyRightYear.innerText = currentYear;

--- a/index.html
+++ b/index.html
@@ -1079,7 +1079,7 @@
       <div class="footer-bottom">
         <div class="container">
           <p class="copyright">
-            &copy; 2024 GameSphere<a href="#"></a>. All Rights Reserved
+            &copy; <strong id="copyright-year"> </strong> <a href="#"> GameSphere </a>. All Rights Reserved
           </p>
 
           <!--
@@ -1102,6 +1102,8 @@
       <ion-icon name="chevron-up"></ion-icon>
     </a>
 
+    <!-- copyright-year Script -->
+     <script src="./copyrightYear.js"></script>
     <!-- 
     - custom js link
   -->


### PR DESCRIPTION
Closes #36 