### PR TITLE
feat: add reviewer assign workflow 

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,8 @@
+addReviewers: true
+
+addAssignees: false
+
+reviewers:
+  - Durgesh4993
+
+numberOfReviewers: 1

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,0 +1,12 @@
+name: "Auto Assign"
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  add-reviews:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v2.0.0
+        with:
+          configuration-path: ".github/auto_assign.yml"


### PR DESCRIPTION
## 🛠️ Related Issue 

<!-- Example: #104 -->
Closes #47 

## Description:
This pull request addresses the need for a GitHub Actions workflow that automates the process of assigning reviewers to pull requests upon their opening. By implementing this feature, we aim to streamline our code review processes and ensure timely feedback from team members.

## Changes made
### Files added
- `.github/workflows/action.yml`
- `.github/auto_assign.yml`

## To run this workflow you need to enable the following permissions :

1. **Go to your project repository settings**
2. **On left pane > Actions > General**

![image](https://github.com/subhashis2204/project-annapurna/assets/130365071/b6748b8d-0d8c-4662-8fb9-4828e049a69e)

3. **Scroll down and Go to Workflow permissions > select "Read and write permissions"**

![image](https://github.com/subhashis2204/project-annapurna/assets/130365071/28c022ba-2ddc-4dbd-a2fa-2cc8c5380009)

4. **Click save and its done.**


## Checklist
- [x] Code follows the project's style guidelines.
- [x] The pull request is linked to the corresponding issue, if applicable.
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] The title of my pull request is a short description of the requested changes.

@Durgesh4993 please review this PR and don't forget to add SWOC and difficulty level label after merging the PR.
Thanks